### PR TITLE
fix: add missing logs directory to app.Dockerfile to prevent build crash

### DIFF
--- a/app.Dockerfile
+++ b/app.Dockerfile
@@ -21,8 +21,8 @@ RUN pip install -r requirements.txt
 # Copy backend code
 COPY metadata_app/backend ./metadata_app/backend/
 
-# Copy logging
-COPY logs/ ./logs
+# Create logging directory (fixes missing local logs folder issue)
+RUN mkdir -p logs
 
 # Copy frontend code and build it
 COPY metadata_app/frontend/ ./metadata_app/frontend/


### PR DESCRIPTION
Issue: 
Git does not track empty directories. Because the logs/ directory is empty in the repository, it is not created locally when cloning the repository. This causes the Docker build to fail at the COPY logs/ ./logs step with a "file not found" error when building a fresh environment.

Fix:
Replaced the COPY logs/ ./logs command with RUN mkdir -p logs in app.Dockerfile. This ensures the directory is reliably created inside the container during the build process, regardless of the host machine's directory structure.

Tested locally on WSL/Ubuntu with a successful Docker build and container spin-up.