### PR TITLE
feat: parse full BUSCO score components in reports

### DIFF
--- a/metadata_app/backend/app/services/busco_parser.py
+++ b/metadata_app/backend/app/services/busco_parser.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Optional
+
+
+_FULL_BUSCO_RE = re.compile(
+    r"""
+    C:(?P<complete>\d+(?:\.\d+)?)%
+    (?:\[
+        S:(?P<single>\d+(?:\.\d+)?)%,
+        D:(?P<duplicated>\d+(?:\.\d+)?)%
+    \])?
+    (?:,F:(?P<fragmented>\d+(?:\.\d+)?)%)?
+    (?:,M:(?P<missing>\d+(?:\.\d+)?)%)?
+    (?:,n:(?P<searched>\d+))?
+    """,
+    re.VERBOSE,
+)
+
+
+@dataclass(frozen=True)
+class BuscoScores:
+    complete: Optional[float] = None
+    single: Optional[float] = None
+    duplicated: Optional[float] = None
+    fragmented: Optional[float] = None
+    missing: Optional[float] = None
+    searched: Optional[int] = None
+
+
+def parse_busco_string(value: object) -> BuscoScores:
+    """Parse a BUSCO summary string into typed components.
+
+    Supports both the full string format, e.g.
+    ``C:98.2%[S:97.5%,D:0.7%],F:0.8%,M:1.0%,n:255``, and older
+    completeness-only values such as ``C:98.2%``.
+    """
+
+    if value is None:
+        return BuscoScores()
+
+    if not isinstance(value, str):
+        value = str(value)
+
+    value = value.strip()
+    if not value:
+        return BuscoScores()
+
+    match = _FULL_BUSCO_RE.search(value)
+    if not match:
+        return BuscoScores()
+
+    groups = match.groupdict()
+    return BuscoScores(
+        complete=_to_float(groups["complete"]),
+        single=_to_float(groups["single"]),
+        duplicated=_to_float(groups["duplicated"]),
+        fragmented=_to_float(groups["fragmented"]),
+        missing=_to_float(groups["missing"]),
+        searched=_to_int(groups["searched"]),
+    )
+
+
+def _to_float(value: Optional[str]) -> Optional[float]:
+    if value is None:
+        return None
+    return float(value)
+
+
+def _to_int(value: Optional[str]) -> Optional[int]:
+    if value is None:
+        return None
+    return int(value)

--- a/metadata_app/backend/app/services/report_annotation_service.py
+++ b/metadata_app/backend/app/services/report_annotation_service.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import logging
 from metadata_app.backend.app.services.annotations_service import generate_tables
+from metadata_app.backend.app.services.busco_parser import parse_busco_string
 from metadata_app.backend.app.services.taxonomy_service import (
     get_descendant_taxa,
     assign_clade_and_species,
@@ -68,18 +69,34 @@ def generate_report(end_date, start_date, group_name, taxon_id, bioproject_id):
     )
 
     if "protein_busco" in anno_wide.columns:
-        extracted = anno_wide["protein_busco"].str.extract(r"C:(\d+\.\d+)%")[0]
+        busco_scores = anno_wide["protein_busco"].apply(parse_busco_string)
+        busco_scores_df = pd.DataFrame(
+            [score.__dict__ for score in busco_scores],
+            index=anno_wide.index,
+        ).rename(
+            columns={
+                "complete": "busco_complete",
+                "single": "busco_single_copy",
+                "duplicated": "busco_duplicated",
+                "fragmented": "busco_fragmented",
+                "missing": "busco_missing",
+                "searched": "busco_genes_searched",
+            }
+        )
+        anno_wide = pd.concat([anno_wide, busco_scores_df], axis=1)
 
-        # Convert to float, but invalid values → None instead of NaN
-        extracted = pd.to_numeric(extracted, errors="coerce")
-        # Store cleaned series back in the DataFrame (optional)
-        anno_wide["busco_complete"] = extracted
         # Compute average only on valid numbers
-        valid = extracted.dropna()
+        valid = anno_wide["busco_complete"].dropna()
 
         average_busco = valid.mean() if not valid.empty else "Not available"
     else:
         anno_wide["protein_busco"] = "Not available"
+        anno_wide["busco_complete"] = pd.NA
+        anno_wide["busco_single_copy"] = pd.NA
+        anno_wide["busco_duplicated"] = pd.NA
+        anno_wide["busco_fragmented"] = pd.NA
+        anno_wide["busco_missing"] = pd.NA
+        anno_wide["busco_genes_searched"] = pd.NA
         average_busco = "Not available"
 
     main_report = anno_wide[

--- a/metadata_app/backend/tests/test_busco_parser.py
+++ b/metadata_app/backend/tests/test_busco_parser.py
@@ -1,0 +1,37 @@
+from metadata_app.backend.app.services.busco_parser import (
+    BuscoScores,
+    parse_busco_string,
+)
+
+
+def test_parse_full_busco_string():
+    value = "C:98.2%[S:97.5%,D:0.7%],F:0.8%,M:1.0%,n:255"
+
+    scores = parse_busco_string(value)
+
+    assert scores == BuscoScores(
+        complete=98.2,
+        single=97.5,
+        duplicated=0.7,
+        fragmented=0.8,
+        missing=1.0,
+        searched=255,
+    )
+
+
+def test_parse_completeness_only_busco_string():
+    scores = parse_busco_string("C:91.4%")
+
+    assert scores == BuscoScores(complete=91.4)
+
+
+def test_parse_returns_empty_scores_for_none():
+    assert parse_busco_string(None) == BuscoScores()
+
+
+def test_parse_returns_empty_scores_for_blank_string():
+    assert parse_busco_string("   ") == BuscoScores()
+
+
+def test_parse_returns_empty_scores_for_malformed_string():
+    assert parse_busco_string("not a busco value") == BuscoScores()


### PR DESCRIPTION
Closes #30

This PR improves BUSCO parsing in `metadata_app/backend/app/services/report_annotation_service.py`.

Currently the reporting flow extracts only BUSCO completeness (`C`) from `protein_busco` strings and silently discards the remaining components. This change adds a small parser utility that extracts the full BUSCO summary (`C`, `S`, `D`, `F`, `M`, and `n`) and wires those values into the report dataframe while preserving the existing average completeness calculation.

### Changes
- add `busco_parser.py` utility with a typed `BuscoScores` dataclass
- parse full BUSCO strings such as `C:98.2%[S:97.5%,D:0.7%],F:0.8%,M:1.0%,n:255`
- preserve compatibility with completeness-only values
- add isolated parser tests

### Notes
I verified the current limitation on the `dev/gb_metadata_handling` branch, where only the completeness percentage is extracted from BUSCO strings in the report annotation service.
This is a small reporting improvement related to the annotation metrics and reporting direction discussed for GSoC Project 3.
